### PR TITLE
Meteor 2.3 compatibility

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,12 +3,12 @@
 Package.describe({
     name: 'socialize:user-model',
     summary: 'A social user package',
-    version: '1.0.4',
+    version: '1.0.5',
     git: 'https://github.com/copleykj/socialize-user-model.git',
 });
 
 Package.onUse(function _(api) {
-    api.versionsFrom('1.10.2');
+    api.versionsFrom(['1.10.2', '2.3']);
 
     api.use([
         'socialize:linkable-model@1.0.5',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@socialize/user-model",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Meteor's socialize:user-model package ported for React Native",
     "main": "entry-rn.js",
     "scripts": {


### PR DESCRIPTION
Add `versionsFrom` to include 2.3 for compatibility with major release of `accounts-base`.

Do not release until 2.3 is released.